### PR TITLE
Fix mp4 video link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Only if you are using MacOS and you have `brew` installed (you really should).
 # Convert gif to video (mp4)
 
 [<img src="./images/image-1.png" width="200">
-](./mp4/animate.mp4 "Click to Watch!")
+](./video/animate.mp4 "Click to Watch!")
 
 ### Using FFmpeg
 


### PR DESCRIPTION
## Changes:

- Fix mp4 video link on README.md when clicking the image

## Please tick the checkboxes below to ensure you have done them:

- [x] Read [Contributing.md](https://github.com/linxea/css-animation/blob/master/.github/CONTRIBUTING.md)
- [x] Be nice
